### PR TITLE
Fix several bugs

### DIFF
--- a/filters/base.py
+++ b/filters/base.py
@@ -91,7 +91,7 @@ def darken(img, value):
     return img_m
 
 def rotate_left(img):
-    return img.rotate(90)
+    return img.rotate(90, expand=True)
 
 def rotate_right(img):
-    return img.rotate(-90)
+    return img.rotate(-90, expand=True)

--- a/interface/menus.py
+++ b/interface/menus.py
@@ -24,7 +24,6 @@ def create_menubar(parent, actions):
 
 def create_toolbar(parent):
     toolbar = Gtk.Toolbar()
-    toolbar.get_style_context().add_class(Gtk.STYLE_CLASS_PRIMARY_TOOLBAR)
 
     new_button = Gtk.ToolButton.new()
     new_button.set_icon_name('document-new')

--- a/interface/tools.py
+++ b/interface/tools.py
@@ -6,10 +6,10 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GdkPixbuf, GLib
 
 def pil_to_pixbuf(img):
-    data = img.tobytes()
-    w, h = img.size
-    data = GLib.Bytes.new(data)
-    pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(data, GdkPixbuf.Colorspace.RGB, False, 8, w, h, w * 3)
+    if img.mode != 'RGB': # pixbuf only support RGB
+        img = img.convert('RGB')
+    data = GLib.Bytes.new(img.tobytes())
+    pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(data, GdkPixbuf.Colorspace.RGB, False, 8, img.width, img.height, img.width * 3)
 
     return pixbuf
 


### PR DESCRIPTION
- Set size of rotate image (add expand parameter)
- Use default toolbar size (remove primary style)
- Support RGBA images opening (with black background :-1: )
