### PR TITLE
Unhardcode launcher icon

### DIFF
--- a/imeditor.desktop
+++ b/imeditor.desktop
@@ -8,6 +8,6 @@ Name=ImEditor
 Comment=Simple & versatile image editor.
 Path=/usr/bin
 Exec=imeditor
-Icon=usr/share/pixmaps/imeditor.png
+Icon=imeditor
 StartupWMClass=imeditor
 MimeType=image/bmp;image/x-icon;image/jpeg;image/png;image/webp;


### PR DESCRIPTION
Since the icon already is installed to `.../share/pixmaps`, a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path (neither the file type extension) in the launcher. 
The icon will be found anyway.

This facilitates icon theming or differently sized icons if you provide such in `.../share/icons/hicolor/<size>/apps`
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.