### PR TITLE
Don't use legacy path for metadata

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ appstream_file = i18n.merge_file(
   output: 'io.github.ImEditor.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
Details: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location